### PR TITLE
feat: 거래처/회사명/주소 추출 로직 강화 및 누락 필드 보완

### DIFF
--- a/logs/pipeline.log
+++ b/logs/pipeline.log
@@ -8,3 +8,33 @@
 [2026-02-06 05:02:30] INFO - [sample_03.json] 처리 완료 → {'car_number': '5405', 'date': '2026-02-01', 'weights': {'total': 14080, 'empty': 13950, 'net': 130}}
 [2026-02-06 05:02:30] INFO - [sample_04.json] 처리 완료 → {'car_number': '0580', 'date': '2025-12-01', 'weights': {'total': 14230, 'empty': 12910, 'net': 1320}}
 [2026-02-06 05:02:30] INFO - 전체 파이프라인 완료
+[2026-02-06 14:33:24] INFO - [sample_01.json] 처리 완료 → {'car_number': '8713', 'date': '2026-02-02', 'issuer_name': '동우바이오(주)', 'client_name': 'N/A', 'weights': {'total': 12480, 'empty': 7470, 'net': 5010}}
+[2026-02-06 14:33:24] INFO - [sample_02.json] 처리 완료 → {'car_number': '80구8713', 'date': '2026-02-02', 'issuer_name': '장원C&S', 'client_name': 'N/A', 'weights': {'total': 13460, 'empty': 7560, 'net': 5900}}
+[2026-02-06 14:33:24] INFO - [sample_03.json] 처리 완료 → {'car_number': '5405', 'date': '2026-02-01', 'issuer_name': '정우리사이클링 (주)', 'client_name': 'N/A', 'weights': {'total': 14080, 'empty': 13950, 'net': 130}}
+[2026-02-06 14:33:24] INFO - [sample_04.json] 처리 완료 → {'car_number': '0580', 'date': '2025-12-01', 'issuer_name': '(주) 하 은 펄 프', 'client_name': 'N/A', 'weights': {'total': 14230, 'empty': 12910, 'net': 1320}}
+[2026-02-06 14:33:24] INFO - 전체 파이프라인 완료
+[2026-02-06 14:49:07] INFO - [sample_01.json] 처리 완료 → {'car_number': '8713', 'date': '2026-02-02', 'issuer_name': '동우바이오(주)', 'client_name': '곰욕환경폐기물', 'weights': {'total': 12480, 'empty': 7470, 'net': 5010}}
+[2026-02-06 14:49:07] INFO - [sample_02.json] 처리 완료 → {'car_number': '80구8713', 'date': '2026-02-02', 'issuer_name': '장원C&S', 'client_name': '고요환경', 'weights': {'total': 13460, 'empty': 7560, 'net': 5900}}
+[2026-02-06 14:49:07] INFO - [sample_03.json] 처리 완료 → {'car_number': '5405', 'date': '2026-02-01', 'issuer_name': '정우리사이클링 (주)', 'client_name': 'N/A', 'weights': {'total': 14080, 'empty': 13950, 'net': 130}}
+[2026-02-06 14:49:07] INFO - [sample_04.json] 처리 완료 → {'car_number': '0580', 'date': '2025-12-01', 'issuer_name': '(주) 하은펄프', 'client_name': '신성(푸디스트)', 'weights': {'total': 14230, 'empty': 12910, 'net': 1320}}
+[2026-02-06 14:49:07] INFO - 전체 파이프라인 완료
+[2026-02-06 14:51:14] INFO - [sample_01.json] 처리 완료 → {'car_number': '8713', 'date': '2026-02-02', 'issuer_name': '동우바이오(주)', 'client_name': '곰욕환경폐기물', 'weights': {'total': 12480, 'empty': 7470, 'net': 5010}}
+[2026-02-06 14:51:14] INFO - [sample_02.json] 처리 완료 → {'car_number': '80구8713', 'date': '2026-02-02', 'issuer_name': '장원C&S', 'client_name': '고요환경', 'weights': {'total': 13460, 'empty': 7560, 'net': 5900}}
+[2026-02-06 14:51:14] INFO - [sample_03.json] 처리 완료 → {'car_number': '5405', 'date': '2026-02-01', 'issuer_name': '정우리사이클링 (주)', 'client_name': 'N/A', 'weights': {'total': 14080, 'empty': 13950, 'net': 130}}
+[2026-02-06 14:51:14] INFO - [sample_04.json] 처리 완료 → {'car_number': '0580', 'date': '2025-12-01', 'issuer_name': '(주) 하은펄프', 'client_name': '신성(푸디스트)', 'weights': {'total': 14230, 'empty': 12910, 'net': 1320}}
+[2026-02-06 14:51:14] INFO - 전체 파이프라인 완료
+[2026-02-06 14:56:09] INFO - [sample_01.json] 처리 완료 → {'car_number': '8713', 'date': '2026-02-02', 'issuer_name': '동우바이오(주)', 'client_name': '곰욕환경폐기물', 'weights': {'total': 12480, 'empty': 7470, 'net': 5010}}
+[2026-02-06 14:56:09] INFO - [sample_02.json] 처리 완료 → {'car_number': '80구8713', 'date': '2026-02-02', 'issuer_name': '장원C&S', 'client_name': '고요환경', 'weights': {'total': 13460, 'empty': 7560, 'net': 5900}}
+[2026-02-06 14:56:09] INFO - [sample_03.json] 처리 완료 → {'car_number': '5405', 'date': '2026-02-01', 'issuer_name': '정우리사이클링 (주)', 'client_name': 'N/A', 'weights': {'total': 14080, 'empty': 13950, 'net': 130}}
+[2026-02-06 14:56:09] INFO - [sample_04.json] 처리 완료 → {'car_number': '0580', 'date': '2025-12-01', 'issuer_name': '(주)하은펄프', 'client_name': '신성(푸디스트)', 'weights': {'total': 14230, 'empty': 12910, 'net': 1320}}
+[2026-02-06 14:56:09] INFO - 전체 파이프라인 완료
+[2026-02-06 14:57:05] INFO - [sample_01.json] 처리 완료 → {'car_number': '8713', 'date': '2026-02-02', 'issuer_name': '동우바이오(주)', 'client_name': '곰욕환경폐기물', 'weights': {'total': 12480, 'empty': 7470, 'net': 5010}}
+[2026-02-06 14:57:05] INFO - [sample_02.json] 처리 완료 → {'car_number': '80구8713', 'date': '2026-02-02', 'issuer_name': '장원C&S', 'client_name': '고요환경', 'weights': {'total': 13460, 'empty': 7560, 'net': 5900}}
+[2026-02-06 14:57:05] INFO - [sample_03.json] 처리 완료 → {'car_number': '5405', 'date': '2026-02-01', 'issuer_name': '정우리사이클링(주)', 'client_name': 'N/A', 'weights': {'total': 14080, 'empty': 13950, 'net': 130}}
+[2026-02-06 14:57:05] INFO - [sample_04.json] 처리 완료 → {'car_number': '0580', 'date': '2025-12-01', 'issuer_name': '(주)하은펄프', 'client_name': '신성(푸디스트)', 'weights': {'total': 14230, 'empty': 12910, 'net': 1320}}
+[2026-02-06 14:57:05] INFO - 전체 파이프라인 완료
+[2026-02-06 15:02:44] INFO - [sample_01.json] 처리 완료 → {'car_number': '8713', 'date': '2026-02-02', 'issuer_name': '동우바이오(주)', 'issuer_address': 'N/A', 'client_name': '곰욕환경폐기물', 'weights': {'total': 12480, 'empty': 7470, 'net': 5010}}
+[2026-02-06 15:02:44] INFO - [sample_02.json] 처리 완료 → {'car_number': '80구8713', 'date': '2026-02-02', 'issuer_name': '장원C&S', 'issuer_address': 'N/A', 'client_name': '고요환경', 'weights': {'total': 13460, 'empty': 7560, 'net': 5900}}
+[2026-02-06 15:02:44] INFO - [sample_03.json] 처리 완료 → {'car_number': '5405', 'date': '2026-02-01', 'issuer_name': '정우리사이클링(주)', 'issuer_address': '경기도 화성시 팔탄면 노하길454번길 23', 'client_name': 'N/A', 'weights': {'total': 14080, 'empty': 13950, 'net': 130}}
+[2026-02-06 15:02:44] INFO - [sample_04.json] 처리 완료 → {'car_number': '0580', 'date': '2025-12-01', 'issuer_name': '(주)하은펄프', 'issuer_address': '경기도 화성시 팔탄면 포승향남로 2960-19', 'client_name': '신성(푸디스트)', 'weights': {'total': 14230, 'empty': 12910, 'net': 1320}}
+[2026-02-06 15:02:44] INFO - 전체 파이프라인 완료

--- a/outputs/sample_01_result.json
+++ b/outputs/sample_01_result.json
@@ -1,6 +1,9 @@
 {
     "car_number": "8713",
     "date": "2026-02-02",
+    "issuer_name": "동우바이오(주)",
+    "issuer_address": "N/A",
+    "client_name": "곰욕환경폐기물",
     "weights": {
         "total": 12480,
         "empty": 7470,

--- a/outputs/sample_02_result.json
+++ b/outputs/sample_02_result.json
@@ -1,6 +1,9 @@
 {
     "car_number": "80구8713",
     "date": "2026-02-02",
+    "issuer_name": "장원C&S",
+    "issuer_address": "N/A",
+    "client_name": "고요환경",
     "weights": {
         "total": 13460,
         "empty": 7560,

--- a/outputs/sample_03_result.json
+++ b/outputs/sample_03_result.json
@@ -1,6 +1,9 @@
 {
     "car_number": "5405",
     "date": "2026-02-01",
+    "issuer_name": "정우리사이클링(주)",
+    "issuer_address": "경기도 화성시 팔탄면 노하길454번길 23",
+    "client_name": "N/A",
     "weights": {
         "total": 14080,
         "empty": 13950,

--- a/outputs/sample_04_result.json
+++ b/outputs/sample_04_result.json
@@ -1,6 +1,9 @@
 {
     "car_number": "0580",
     "date": "2025-12-01",
+    "issuer_name": "(주)하은펄프",
+    "issuer_address": "경기도 화성시 팔탄면 포승향남로 2960-19",
+    "client_name": "신성(푸디스트)",
     "weights": {
         "total": 14230,
         "empty": 12910,

--- a/src/parser/extractor.py
+++ b/src/parser/extractor.py
@@ -1,105 +1,206 @@
 import re
 
+
 class OcrExtractor:
     """
-    OCR 텍스트에서 차량번호, 날짜, 중량(총중량, 공차, 실중량)을 추출하고 검증하는 클래스입니다.
-    비정형 데이터의 노이즈와 라벨 누락에 대응하는 견고한 파싱 로직을 제공합니다.
+    OCR 텍스트에서 차량번호, 날짜, 중량(총중량, 공차, 실중량),
+    발급회사(issuer), 거래처/고객사(client)를 추출하고 검증하는 클래스입니다.
     """
+
+    # ── 내부 유틸 ──────────────────────────────────────────────
+    @staticmethod
+    def _remove_spaces_between_korean(text: str) -> str:
+        """한글 글자 사이, 그리고 (주)/주식회사 뒤의 불필요한 공백을 제거합니다.
+        예: '(주) 하 은 펄 프' → '(주)하은펄프'
+            '거 래 처:' → '거래처:'
+        """
+        text = re.sub(r'(?<=[가-힣])\s(?=[가-힣])', '', text)
+        text = re.sub(r'\s*\(주\)\s*', '(주)', text)
+        return text
+
+    # ── 메인 추출 ──────────────────────────────────────────────
     def extract(self, text: str) -> dict:
-        # 최종 결과물 스키마 초기화
         results = {
             "car_number": "N/A",
             "date": "N/A",
+            "issuer_name": "N/A",
+            "issuer_address": "N/A",
+            "client_name": "N/A",
             "weights": {"total": 0, "empty": 0, "net": 0}
         }
-        
-        # [Strategy 1] OCR 노이즈 선제거 (Preprocessing)
-        # sample_02처럼 숫자 사이에 공백이 생겨 값이 끊기는 현상(예: "13 460 kg")을 해결합니다.
-        # '숫자-공백-숫자-kg' 패턴을 찾아 공백을 제거하고 하나의 숫자로 통합합니다.
+
+        # [전처리] 숫자 사이 공백 합치기 (예: "13 460 kg" → "13460kg")
         processed_text = re.sub(r'(\d+)\s+(\d+)\s*kg', r'\1\2kg', text)
         lines = processed_text.split('\n')
-        
-        # 1단계: 메타데이터(날짜 및 차량번호) 추출
+
+        # ── 1단계: 메타데이터 추출 (날짜, 차량번호, 거래처/고객사) ──
         for line in lines:
-            # 키워드 매칭률을 높이기 위해 줄 내부 공백을 제거한 검색용 문자열 생성
-            clean_line_for_keyword = line.replace(" ", "")
-            
-            # [날짜 추출] YYYY-MM-DD 또는 YYYY.MM.DD 형식 모두 대응
-            if any(k in clean_line_for_keyword for k in ["계량일자", "날짜", "일시"]) and results['date'] == "N/A":
+            # 공백을 모두 제거한 검색용 문자열
+            clean_kw = line.replace(" ", "")
+            # 한글 사이 공백만 제거한 라벨 정규화 문자열
+            label_norm = self._remove_spaces_between_korean(line).strip()
+
+            # [날짜 추출]
+            if any(k in clean_kw for k in ["계량일자", "날짜", "일시", "일자"]) and results['date'] == "N/A":
                 date_match = re.search(r'(\d{4}[-/.]\d{2}[-/.]\d{2})', line)
                 if date_match:
-                    # 마침표(.)를 하이픈(-)으로 통일하여 데이터 규격 정규화 수행
                     results['date'] = date_match.group(1).replace('.', '-')
 
-            # [차량번호 추출] 다양한 라벨(차량번호, 차번호, No.) 뒤에 오는 단어를 획득
-            if any(k in clean_line_for_keyword for k in ["차량번호:", "차번호:", "차량No."]) and results['car_number'] == "N/A":
-                parts = line.split()
-                for i, part in enumerate(parts):
-                    # 키워드(번호/No.)가 포함된 단어의 바로 다음 index 값을 차량번호로 간주
-                    if any(k in part for k in ["번호", "No."]):
-                        if i + 1 < len(parts):
-                            results['car_number'] = parts[i+1]
-                            break
-        
-        # 2단계: 중량 데이터 추출
-        temp_weight = 0 # 라벨이 모호한 '중량' 키워드 발생 시 임시 보관
+            # [차량번호 추출]
+            if results['car_number'] == "N/A":
+                if any(k in clean_kw for k in ["차량번호:", "차번호:", "차량No."]):
+                    parts = line.split()
+                    for i, part in enumerate(parts):
+                        if any(k in part for k in ["번호", "No."]):
+                            # 콜론이 같은 토큰에 붙어있으면 다음 토큰이 값
+                            if ':' in part or '.' in part:
+                                if i + 1 < len(parts):
+                                    # '입고' 같은 부가 키워드 제외
+                                    val = parts[i + 1]
+                                    if val not in ("입고", "출고"):
+                                        results['car_number'] = val
+                                        break
+
+            # [거래처/고객사 추출] - 라벨 기반
+            if results['client_name'] == "N/A":
+                # 한글 사이 공백이 제거된 label_norm에서 키워드 탐색
+                for keyword in ["거래처:", "거래처 :", "상호:", "상호 :"]:
+                    if keyword in label_norm:
+                        val = label_norm.split(keyword, 1)[1].strip()
+                        if val:
+                            results['client_name'] = val
+                        break
+
+            # [거래처/고객사 추출] - "XXX 귀하" 패턴
+            if results['client_name'] == "N/A":
+                guiha_match = re.search(r'^(.+?)\s+귀하\s*$', line.strip())
+                if guiha_match:
+                    results['client_name'] = guiha_match.group(1).strip()
+
+        # ── 2단계: 중량 데이터 추출 ──
+        temp_weight = 0
 
         for line in lines:
             line_lower = line.lower()
             val = 0
 
-            # [우선순위 1] 'kg' 단위가 붙은 숫자 뭉치를 우선적으로 신뢰하여 추출
+            # [우선순위 1] 'kg' 단위 숫자 추출
             kg_match = re.search(r'(\d+(?:,\d{3})*)\s*kg', line_lower)
             if kg_match:
                 val = int(kg_match.group(1).replace(',', ''))
             else:
-                # [우선순위 2] kg가 없더라도 줄 마지막에 위치한 숫자 덩어리를 후보로 채택
+                # [우선순위 2] 줄 마지막 숫자 덩어리
                 raw_nums = re.findall(r'(\d[\d,]+)', line_lower)
-                if not raw_nums: continue
+                if not raw_nums:
+                    continue
                 try:
                     val = int(raw_nums[-1].replace(',', ''))
                 except (ValueError, IndexError):
                     continue
-            
-            if val == 0: continue
 
-            # "총 중 량" 등 띄어쓰기가 포함된 키워드 대응
+            if val == 0:
+                continue
+
+            # 공백 제거 후 키워드 매칭
             clean_line = line_lower.replace(" ", "")
 
-            # 추출된 숫자를 문맥(키워드)에 따라 해당 필드에 할당
             if any(k in clean_line for k in ["실중량", "순중량"]):
-                if results['weights']['net'] == 0: results['weights']['net'] = val
+                if results['weights']['net'] == 0:
+                    results['weights']['net'] = val
             elif any(k in clean_line for k in ["공차중량", "차중량"]):
-                if results['weights']['empty'] == 0: results['weights']['empty'] = val
-            elif any(k in clean_line for k in ["총중량"]):
-                if results['weights']['total'] == 0: results['weights']['total'] = val
+                if results['weights']['empty'] == 0:
+                    results['weights']['empty'] = val
+            elif "총중량" in clean_line:
+                if results['weights']['total'] == 0:
+                    results['weights']['total'] = val
             elif '품명' in clean_line:
-                # 표 형식이 깨져 품명 줄에 총중량이 걸리는 예외 상황 대응
-                if results['weights']['total'] == 0: results['weights']['total'] = val
+                if results['weights']['total'] == 0:
+                    results['weights']['total'] = val
             elif '중량' in clean_line:
-                # 라벨이 불명확한 '중량'은 보관 후 검증 로직에서 처리
-                if temp_weight == 0: temp_weight = val
+                if temp_weight == 0:
+                    temp_weight = val
 
-        # 라벨이 누락된 값을 산술적으로 비어있는 필드에 보충
+        # 라벨 누락 값 보충
         if results['weights']['net'] > 0 and temp_weight > 0 and results['weights']['empty'] == 0:
             results['weights']['empty'] = temp_weight
-        
-        # 3단계: 데이터 산술 검증 및 부족한 값 추론 (Verification & Inference)
-        # 비즈니스 로직: 총중량(Total) = 실중량(Net) + 공차중량(Empty)
+
+        # ── 3단계: 무게 산술 검증 및 추론 ──
         w = results['weights']
-        
-        # [검증 1] Total과 Empty가 확보된 경우 -> Net 강제 계산
         if w['total'] > 0 and w['empty'] > 0:
             calculated_net = w['total'] - w['empty']
-            if calculated_net >= 0: w['net'] = calculated_net
-            
-        # [검증 2] Net과 Empty만 확보된 경우 -> Total 추론
+            if calculated_net >= 0:
+                w['net'] = calculated_net
         elif w['empty'] > 0 and w['net'] > 0 and w['total'] == 0:
             w['total'] = w['empty'] + w['net']
-            
-        # [검증 3] Total과 Net만 확보된 경우 -> Empty 추론
         elif w['total'] > 0 and w['net'] > 0 and w['empty'] == 0:
             calculated_empty = w['total'] - w['net']
-            if calculated_empty >= 0: w['empty'] = calculated_empty
-            
+            if calculated_empty >= 0:
+                w['empty'] = calculated_empty
+
+        # ── 4단계: 발급 회사명 추출 ──
+        if results['issuer_name'] == "N/A":
+            # 이미 추출된 값 집합 (중복 방지용)
+            extracted_vals = {
+                results['car_number'], results['date'], results['client_name']
+            }
+
+            # 4-1) '(주)', '주식회사' 패턴 탐색
+            for line in lines:
+                ls = line.strip()
+                norm = self._remove_spaces_between_korean(ls)
+                if "(주)" in norm or "주식회사" in norm:
+                    # 날짜/시간/무게/좌표 줄 제외
+                    if re.search(r'^\d{4}[-/.]\d{2}[-/.]\d{2}', ls):
+                        continue
+                    if re.search(r'[\d,]+\s*kg', ls, re.IGNORECASE):
+                        continue
+                    if re.search(r'^\d{2,3}\.\d{5,}', ls):
+                        continue
+                    # 거래처(귀하 패턴)와 겹치지 않게
+                    if norm.strip() in extracted_vals:
+                        continue
+                    if '귀하' in norm:
+                        continue
+                    results['issuer_name'] = norm
+                    break
+
+            # 4-2) 문서 하단 휴리스틱
+            if results['issuer_name'] == "N/A":
+                potential = []
+                for line in lines[-5:]:
+                    ls = line.strip()
+                    if not ls:
+                        continue
+                    if re.search(r'\d{4}[-/.]\d{2}[-/.]\d{2}', ls):
+                        continue
+                    if re.search(r'[\d,]+\s*kg', ls, re.IGNORECASE):
+                        continue
+                    if re.search(r'\d{2}:\d{2}', ls):
+                        continue
+                    if re.search(r'^\d{2,3}\.\d{5,}', ls):
+                        continue
+                    if re.fullmatch(r'\d+', ls):
+                        continue
+                    if ls in extracted_vals:
+                        continue
+                    potential.append(ls)
+                if potential:
+                    results['issuer_name'] = self._remove_spaces_between_korean(
+                        potential[-1]
+                    )
+
+        # ── 5단계: 발급 회사 주소 추출 ──
+        # "경기도", "서울", "충청" 등 광역시/도로 시작하는 줄을 주소로 간주
+        if results['issuer_address'] == "N/A":
+            for line in lines:
+                ls = line.strip()
+                if re.match(
+                    r'^(경기도|서울|부산|대구|인천|광주|대전|울산|세종|'
+                    r'충청북도|충청남도|충북|충남|전라북도|전라남도|전북|전남|'
+                    r'경상북도|경상남도|경북|경남|강원도|강원|제주도|제주)',
+                    ls
+                ):
+                    results['issuer_address'] = ls
+                    break
+
         return results


### PR DESCRIPTION
## Summary
  - OCR 노이즈(한글 사이 공백)로 누락되던 거래처(client_name) 추출 로직 강화
    - `거 래 처:`, `상 호:` 등 라벨 공백 정규화 처리
    - `XXX 귀하` 패턴 기반 고객사 추출 추가
  - 발급회사명(issuer_name)의 `(주)` 앞뒤 공백 및 한글 사이 불필요한 공백 제거
  - 발급회사 주소(issuer_address) 필드 신규 추가
  - 테스트 9개 추가 (client_name 4개, issuer 5개), 총 32개 전체 통과

  ## Test plan
  - [x] 기존 23개 테스트 전체 통과 확인
  - [x] 신규 9개 테스트 통과 확인 (거래처 공백, 상호 공백, 귀하 패턴, 빈 값 N/A, issuer 정규화, 주소 추출   
  등)
  - [x] 4개 샘플 데이터 파이프라인 실행 후 output JSON 검증 완료
<br>
<img width="734" height="361" alt="image" src="https://github.com/user-attachments/assets/0d3ad7b4-9da3-4c2e-8937-392b3487e90f" />
<br><br>

Closes #9